### PR TITLE
[CLI] remove 'no ports message' from cli

### DIFF
--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -131,8 +131,6 @@ class InterfaceAliasConverter(object):
 
 
         if not self.port_dict:
-            if not device_info.is_supervisor():
-                click.echo(message="Configuration database contains no ports")
             self.port_dict = {}
 
         for port_name in self.port_dict:


### PR DESCRIPTION
Signed-off-by: tomeri <tomeri@nvidia.com>

#### What I did
removed message "Configuration database contains no ports" from cli 
when we remove all the ports or starting with a system without ports we receive this message each time we are using cli.

#### How I did it
removed it from cli.py
#### How to verify it
manual tests

#### Previous command output (if the output of a command-line utility has changed)
For example, show interfaces status displayed this message:
"Configuration database contains no ports"
#### New command output (if the output of a command-line utility has changed)
now it just prints the output of this show command without this message